### PR TITLE
UserEvents handling fix

### DIFF
--- a/Asterisk.2013/Asterisk.NET/Manager/AsteriskManagerEvents.cs
+++ b/Asterisk.2013/Asterisk.NET/Manager/AsteriskManagerEvents.cs
@@ -228,11 +228,11 @@ namespace Sufficit.Asterisk.Manager
             ConstructorInfo? constructor = null;
 
             string eventKey = GetEventKey(attributes["event"]);
-            if (eventKey == "userevent")
+            if (eventKey == "user")
             {
                 string userevent = attributes["userevent"].Trim().ToLowerInvariant();
                 if (!string.IsNullOrWhiteSpace(userevent))
-                    eventKey = userevent;
+                    eventKey = "user" + userevent;
             }
 
             if (registeredEventClasses.ContainsKey(eventKey))


### PR DESCRIPTION
Hello,

migrating to your library i found out that there is issue with handling `userevents` there are mistakes with keys.

`GetEventKey` removes sufix `event`, to compared should be `user` not `userevent`
Later, the `user` is added as prefix to user event registered classes so event key needs to have this prefixed.

